### PR TITLE
Fix link colors in article summary and line-breaks

### DIFF
--- a/src/index.tmpl.js
+++ b/src/index.tmpl.js
@@ -60,7 +60,6 @@ const style = html`
 
     p {
       margin-block: 0.5em;
-      line-break: anywhere;
     }
 
     h1,
@@ -117,7 +116,7 @@ const style = html`
       font-style: italic;
       opacity: 75%;
     }
-    .article summary a {
+    .article-entry summary a {
       color: var(--palette--frost);
       line-break: anywhere;
     }


### PR DESCRIPTION
It was the class name that was still the old one. Oops! 

Fixes #2
Fixes #3